### PR TITLE
Fix migration for latest container changes

### DIFF
--- a/src/db_util.rs
+++ b/src/db_util.rs
@@ -127,13 +127,3 @@ pub fn delete_db_entry(uuid: &str, database: &Connection) -> anyhow::Result<()> 
 
     Ok(())
 }
-
-pub async fn async_db_cleanup(db_clone: Arc<Mutex<Connection>>) -> ! {
-    loop {
-        match rm_file_after_expiration(&db_clone).await {
-            Ok(ok) => ok,
-            Err(e) => eprintln!("Error when running file cleanup: {}", e),
-        };
-        std::thread::sleep(std::time::Duration::from_secs(15));
-    }
-}

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 use tempfile::Builder;
 use thiserror::Error;
 
-const REGISTRY_URL:&str = "registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/migrate-wicked-git:latest";
+const REGISTRY_URL:&str = "registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/wicked2nm:latest";
 
 #[derive(Error, Debug)]
 pub enum MigrateError {
@@ -57,15 +57,15 @@ fn migrate_files(
 
     let arguments_str = if files[0].file_type == FileType::Ifcfg {
         format!(
-            "run -e \"MIGRATE_WICKED_CONTINUE_MIGRATION=true\" --rm -v {}:/etc/sysconfig/network:z {}",
+            "run -e \"W2NM_CONTINUE_MIGRATION=true\" -e \"W2NM_WITHOUT_NETCONFIG=true\" --rm -v {}:/etc/sysconfig/network:z {}",
             migration_target_path,
-                REGISTRY_URL
+            REGISTRY_URL
         )
     } else {
         format!("run --rm -v {}:/migration-tmpdir:z {} bash -c
-            \"migrate-wicked migrate -c /migration-tmpdir/ && mkdir /migration-tmpdir/NM-migrated && cp -r /etc/NetworkManager/system-connections /migration-tmpdir/NM-migrated\"",
+            \"wicked2nm migrate -c --without-netconfig /migration-tmpdir/ && mkdir /migration-tmpdir/NM-migrated && cp -r /etc/NetworkManager/system-connections /migration-tmpdir/NM-migrated\"",
             migration_target_path,
-                REGISTRY_URL,
+            REGISTRY_URL,
         )
     };
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -11,7 +11,8 @@ use std::process::Command;
 use tempfile::Builder;
 use thiserror::Error;
 
-const REGISTRY_URL:&str = "registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/wicked2nm:latest";
+const REGISTRY_URL: &str =
+    "registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/wicked2nm:latest";
 
 #[derive(Error, Debug)]
 pub enum MigrateError {
@@ -93,4 +94,14 @@ pub fn migrate(files: Vec<File>, database: &Connection) -> Result<String, Migrat
 
     let uuid = add_migration_result_to_db(migration_target_path, log, database)?;
     Ok(uuid)
+}
+
+pub fn pull_latest_migration_image() -> anyhow::Result<()> {
+    let output = Command::new("podman")
+        .args(shlex::split(&format!("pull {}", REGISTRY_URL)).unwrap())
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+    Ok(())
 }


### PR DESCRIPTION
The migration part still used an old registry image and also some additional changes were required because of the rename `wicked-migrate` -> `wicked2nm`.
I also decided to add a job that every 15 minutes pulls in the latest image to ensure the servers image is up to date. And also as otherwise if the image isn't present a user may be shown the following in their warnings:
```
Trying to pull registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/wicked2nm:latest...
Getting image source signatures
Copying blob sha256:a8d3fd287492b7f3d7458a4773ec3feb1d26e899c131835b7a017fbad7ed07af
Copying blob sha256:c5db621b0df87ff93b1e24f32df76ac75586eff4698b9526cb8ff89613976acf
Copying config sha256:a36d50c9634415ba35eedaf112c7e4629f4b080b4da7947178c0cba0f8c324d9
Writing manifest to image destination
```